### PR TITLE
Add prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": false
+}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Extensions: Prettier, postcss-syntax, GraphQL, ESLint, DotENV, Babel ES6/ES7
 npm i -g babel-eslint
 ```
 
+For Prettier, it is recommended to add to the editor's `settings.json` to run on save.
+
+```
+"editor.formatOnSave": true
+```
+
 ### Seeding
 
 If you want to seed the database with sample data, run the below command:


### PR DESCRIPTION
Add prettierrc and instruction on how to better use Prettier in VSCode.

The main setting that I think we should enforce is `"tabWidth": 4`, since the default tabWidth of Prettier plugin is 2 and in the project it is 4. I also put semicolon and doubleQuote settings which are same as default so it won't hurt, not really necessary but I think they are nice to have.
![image](https://user-images.githubusercontent.com/25751050/41808388-5ff36dee-76e5-11e8-85e1-430d8c4f88fc.png)
I checked carefully to make sure that using this prettierrc setting the existing files won't change when formatting by trying to save and see if anything modified. 