### PR TITLE
fix wiring of tags.posts

### DIFF
--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -158,6 +158,10 @@ interface ParsedGraphqlRequest {
 
 function parseGraphqlRequest(req: Request): ParsedGraphqlRequest {
   const parsedReq = req.body;
+  if (!parsedReq) {
+    throw new TypeError("requestBody is undefined");
+  }
+
   if (typeof parsedReq.query !== "string") {
     throw new TypeError("requestBody.query is not found");
   }

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -10,7 +10,8 @@ import Taxonomy from "./taxonomy";
 import Theme from "./theme";
 import dbConfig from "../../config/db.config";
 
-const env = process.env.NODE_ENV || "dev";
+let env = process.env.NODE_ENV || "dev";
+if (env === "development") env = "dev";
 const config = dbConfig[env];
 
 // establish  database connection

--- a/src/api/resolvers/post.js
+++ b/src/api/resolvers/post.js
@@ -216,23 +216,7 @@ const postresolver = {
     },
     tags: async post => {
       const taxonomies = await post.getTaxonomies();
-      return taxonomies
-        .filter(item => item.type === "post_tag")
-        .map(item => {
-          const type = "tag";
-          item.slug = "/" + type + "/" + item.slug;
-          const posts = item.getPosts();
-          item.posts = {
-            count: posts.then(items => items.length),
-            rows: posts.then(rows =>
-              rows.map(post => {
-                post.dataValues = normalizePost(post.dataValues);
-                return post;
-              }),
-            ),
-          };
-          return item;
-        });
+      return taxonomies.filter(item => item.type === "post_tag");
     },
   },
 };

--- a/src/api/resolvers/taxonomy.js
+++ b/src/api/resolvers/taxonomy.js
@@ -31,15 +31,17 @@ export default {
 
       const taxonomies = await models.Taxonomy.findAll(conditions);
 
-      return taxonomies;
+      const type = "tag";
+
+      return taxonomies.map(taxonomy => {
+        taxonomy.slug = config.BASE_NAME + "/" + type + "/" + taxonomy.slug;
+        return taxonomy;
+      });
     },
   },
 
   Taxonomy: {
     async posts(taxonomy) {
-      const type = "tag";
-      taxonomy.slug = config.BASE_NAME + "/" + type + "/" + taxonomy.slug;
-      // promise
       const posts = await taxonomy.getPosts();
       return {
         count: posts.length,

--- a/src/api/resolvers/taxonomy.js
+++ b/src/api/resolvers/taxonomy.js
@@ -31,24 +31,26 @@ export default {
 
       const taxonomies = await models.Taxonomy.findAll(conditions);
 
-      return taxonomies.map(item => {
-        const type = "tag";
-        item.slug = config.BASE_NAME + "/" + type + "/" + item.slug;
-        // promise
-        const posts = item.getPosts();
-        item.posts = {
-          count: posts.then(items => items.length),
-          rows: posts.then(rows =>
-            rows.map(post => {
-              post.dataValues = normalizePost(post.dataValues);
-              return post;
-            }),
-          ),
-        };
-        return item;
-      });
+      return taxonomies;
     },
   },
+
+  Taxonomy: {
+    async posts(taxonomy) {
+      const type = "tag";
+      taxonomy.slug = config.BASE_NAME + "/" + type + "/" + taxonomy.slug;
+      // promise
+      const posts = await taxonomy.getPosts();
+      return {
+        count: posts.length,
+        rows: posts.map(post => {
+          post.dataValues = normalizePost(post.dataValues);
+          return post;
+        }),
+      };
+    },
+  },
+
   Mutation: {
     updateTaxonomy: async (root, args, { models }) => {
       if (args.id == 0) {


### PR DESCRIPTION
GraphQL JIT does not yet resolve promises in object locations which will lead to trying to convert a promise type to a object / array / number / string. So, we move those things to a separate resolver. This also optimizes where posts were unnecessarily queried when not using the field posts in tags.