### PR TITLE
Fix initial save

### DIFF
--- a/src/components/post-settings/publishButton.tsx
+++ b/src/components/post-settings/publishButton.tsx
@@ -35,16 +35,17 @@ const PublishButton: React.VFC<Props> = ({ postId, menu }) => {
     const navigationPages = getPagesFromMenu(menu);
 
     const navLinkedWithTags = post.tags?.find((tag) =>
-      navigationTags?.includes(tag.name),
+      navigationTags?.includes(tag.name.toLowerCase()),
     );
     const navLinkedWithPages = navigationPages?.find(
-      (page) => page === post.slug?.replace("/page/", ""),
+      (page) => page === post.slug?.replace("/page/", "").toLocaleLowerCase(),
     );
 
     if (active) {
       if (post.type === PostTypes.Post) {
         if (post.tags?.length === 0) return warnNoTags();
-        if (!navLinkedWithTags) return tagNotLinkedWithNavigation();
+        if (!navLinkedWithTags)
+          return tagNotLinkedWithNavigation(navigationTags);
       } else {
         if (!navLinkedWithPages) return pageNotLinkedWithNavigation();
       }

--- a/src/components/post-settings/warnings.tsx
+++ b/src/components/post-settings/warnings.tsx
@@ -11,7 +11,8 @@ export function warnNoTags() {
     content: (
       <div>
         You have not added tags to your post. Add a tag/tags and ensure its set
-        up in Settings → Navigation.
+        up in Settings → Navigation. This is necessary for your post to be
+        visible in your homepage.
         <p>
           <a
             target="_blank"
@@ -26,7 +27,7 @@ export function warnNoTags() {
   });
 }
 
-export function tagNotLinkedWithNavigation() {
+export function tagNotLinkedWithNavigation(tags: string[]) {
   Modal.warning({
     className: "tags-notlinked-modal", //used by cypress
     zIndex: 999999999,
@@ -36,7 +37,9 @@ export function tagNotLinkedWithNavigation() {
     },
     content: (
       <div>
-        You have not linked any tags of this post in Navigation. <br />
+        Atleast one tag of this post should be linked in Navigation. <br />
+        {tags.length > 0 &&
+          `Currently the navigation menu has these tags - ${tags.join(", ")}`}
         You can do so by going to Settings → Navigation → New. Then give a name
         and select a tag from the dropdown.
         <p>

--- a/src/graphql/resolvers/helpers.ts
+++ b/src/graphql/resolvers/helpers.ts
@@ -73,7 +73,11 @@ export async function getImageDimensions(
 
 export const setImageWidthAndHeightInHtml = async (html: string) => {
   try {
-    const $ = cheerio.load(html, { xmlMode: true, decodeEntities: false });
+    const $ = cheerio.load(html, {
+      xmlMode: true,
+      decodeEntities: false,
+      normalizeWhitespace: false,
+    });
     logger.debug("Setting image width and height inside html");
     const $bodyImages = $("img");
 

--- a/src/graphql/resolvers/post.mutation.ts
+++ b/src/graphql/resolvers/post.mutation.ts
@@ -348,8 +348,13 @@ async function getContentAttrs(
   html?: string,
   newStatus?: PostStatusOptions,
 ) {
+  console.log("--", html);
   if (html) {
-    const $ = Cheerio.load(html);
+    const $ = Cheerio.load(html, {
+      xmlMode: true,
+      decodeEntities: false,
+      normalizeWhitespace: false,
+    });
     // remove all tooltips which are used for grammar checking
     $("[data-tippy-root]").remove();
     $("head").remove();
@@ -366,6 +371,7 @@ async function getContentAttrs(
   }
   if (savingDraft(prevPost.status, newStatus)) {
     const _html = html || prevPost.html_draft || empty;
+    console.log(_html);
     return {
       html_draft: _html,
       reading_time: getReadingTimeFromHtml(_html),


### PR DESCRIPTION
When you open an existing post, it would display the saving indicator. Ideally, it should not display this since as a user you didnt make any change yet. This PR fixes this issue.