### PR TITLE
chore: remove lazy sizes

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "letterpad-admin",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Abhishek Saha",
   "license": "MIT",
   "prisma": {

--- a/apps/admin/src/graphql/utils/imageAttributs.ts
+++ b/apps/admin/src/graphql/utils/imageAttributs.ts
@@ -24,12 +24,10 @@ export const getImageAttrs = (
   if (url.hostname.includes("cloudinary")) {
     const srcSet = sizes.map((w) => makeCloudinaryImage(src, w)).join(", ");
     return {
-      src: makeCloudinaryUrl(src, sizes[sizes.length - 1]),
+      src: base64Url,
       sizes: srcSizes,
-      "data-srcset": srcSet,
-      srcSet: base64Url,
+      srcSet: srcSet,
       loading: "lazy",
-      class: "lazyload",
     };
   }
 
@@ -37,12 +35,10 @@ export const getImageAttrs = (
     base64Url = makeUnsplashUrl(src, 30);
     const srcSet = sizes.map((w) => makeUnsplashImage(src, w)).join(", ");
     return {
-      src: makeUnsplashUrl(src, sizes[sizes.length - 1]),
+      src: base64Url,
       sizes: srcSizes,
-      "data-srcset": srcSet,
-      srcSet: base64Url,
+      srcSet: srcSet,
       loading: "lazy",
-      class: "lazyload",
     };
   }
   return {

--- a/apps/admin/src/pages/_app.tsx
+++ b/apps/admin/src/pages/_app.tsx
@@ -2,7 +2,6 @@ import { ApolloProvider } from "@apollo/client";
 import { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";
 import React from "react";
-import "lazysizes";
 
 import "ui/css/tailwind.css";
 import "../../public/css/globals.css";

--- a/apps/client/pages/_app.tsx
+++ b/apps/client/pages/_app.tsx
@@ -3,7 +3,6 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import Script from 'next/script';
 import { ThemeProvider } from 'next-themes';
-import 'lazysizes';
 
 import 'ui/css/tailwind.css';
 import 'ui/css/editor.css';

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "packageManager": "yarn@1.22.19",
   "dependencies": {
     "axios": "^1.2.0",
-    "lazysizes": "^5.3.2",
     "react-icons": "^4.6.0"
   }
 }


### PR DESCRIPTION
Remove lazy sizes library. This is not more required as browsers not support `loading=lazy` by default.