### PR TITLE
change docker run command doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ yarn start
 ```
 ### Using Docker
 ```sh
- docker run 
-  -v 'data:/app/apps/admin/prisma/sqlite/data' 
-  -p 3001:3001 
-  -p 3000:3000 
-  -e DATABASE_URL='file:data/letterpad.sqlite' 
-  -e SECRET_KEY='provide-a-secret-key' 
-  -e EMAIL="xxx@xxx.com" 
-  -e PASSWORD='xxxxxxxxxxx' 
-  abhisheksaha11/letterpad
+docker run \
+-v 'data:/app/apps/admin/prisma/sqlite/data' \
+-p 3001:3001 \
+-p 3000:3000 \
+-e DATABASE_URL='file:data/letterpad.sqlite' \
+-e SECRET_KEY='provide-a-secret-key' \
+-e EMAIL="xxx@xxx.com" \
+-e PASSWORD='xxxxxxxxxxx' \
+abhisheksaha11/letterpad
 ```
 ### Options:
 Letterpad can be configured using environemt variables. The below are all possible options.


### PR DESCRIPTION
Since the docker run command in the doc returns
```sh
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Create and run a new container from an image
-v: command not found
-p: command not found
-p: command not found
-e: command not found
-e: command not found
-e: command not found
-e: command not found
bash: abhisheksaha11/letterpad: No such file or directory
```
I suggest change to
```sh
docker run \
-v 'data:/app/apps/admin/prisma/sqlite/data' \
-p 3001:3001 \
-p 3000:3000 \
-e DATABASE_URL='file:data/letterpad.sqlite' \
-e SECRET_KEY='provide-a-secret-key' \
-e EMAIL="xxx@xxx.com" \
-e PASSWORD='xxxxxxxxxxx' \
abhisheksaha11/letterpad
```
for clearance and accuracy.