### PR TITLE
Improve filter colors in admin posts table

### DIFF
--- a/apps/admin/src/components/filters/index.tsx
+++ b/apps/admin/src/components/filters/index.tsx
@@ -183,7 +183,7 @@ const Badge = ({ label, count, active, onClick }) => {
         {
           "border-transparent bg-slate-100 text-slate-500 shadow-sm dark:bg-slate-700 dark:text-slate-400":
             !active,
-          "border-slate-300 bg-slate-200  text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400":
+          "border-slate-500 bg-slate-500  text-slate-100 dark:border-blue-700 dark:bg-blue-600 dark:text-blue-200":
             active,
         }
       )}
@@ -194,7 +194,7 @@ const Badge = ({ label, count, active, onClick }) => {
           "flex h-5 w-5 items-center justify-center rounded-full text-xs",
           {
             "bg-slate-200 dark:bg-slate-800": !active,
-            "bg-slate-300 text-slate-600 dark:bg-slate-900 dark:text-slate-400 ":
+            "bg-slate-700 text-blue-100 dark:bg-blue-800 dark:text-blue-100":
               active,
           }
         )}

--- a/apps/admin/src/components/top-bar/topBar.tsx
+++ b/apps/admin/src/components/top-bar/topBar.tsx
@@ -1,14 +1,11 @@
 import { CgClose } from "react-icons/cg";
 import { HiOutlineMenu } from "react-icons/hi";
-import { Button, useResponsive, useResponsiveLayout } from "ui";
-
-import { useSavingIndicator } from "@/hooks/useSavingIndicator";
+import { Button, useResponsiveLayout } from "ui";
 
 import FeedbackForm from "../feedback-form";
 import ThemeSwitcher from "../theme-switcher";
 
 export const TopBar = () => {
-  const SavingIndicator = useSavingIndicator();
   const { sidebarVisible, setSidebarVisible } = useResponsiveLayout();
   return (
     <div className="flex flex-row items-center justify-between py-4">
@@ -20,7 +17,6 @@ export const TopBar = () => {
           {sidebarVisible ? <CgClose /> : <HiOutlineMenu />}
         </Button>
       </div>
-      {SavingIndicator}
       <div className="flex flex-row gap-2">
         <Button size="small" variant="ghost">
           <a


### PR DESCRIPTION
The filters which were active was hard to understand.
Before:
<img width="451" alt="Screenshot 2023-08-13 at 00 24 34" src="https://github.com/letterpad/letterpad/assets/1502352/7f0a8f90-9389-47c1-ad01-8a873be971ac">
After
<img width="492" alt="Screenshot 2023-08-13 at 00 24 23" src="https://github.com/letterpad/letterpad/assets/1502352/b517eeda-5555-49ce-b03e-c80cdb0f4e6c">
