### PR TITLE
fix: menu bar background

### DIFF
--- a/apps/client/src/components/menu.tsx
+++ b/apps/client/src/components/menu.tsx
@@ -22,7 +22,7 @@ export const Menu = ({ routes }) => {
   );
 
   return (
-    <div className="lp-menu flex uppercase font-bold text-xs md:text-sm gap-4 md:justify-start justify-center pt-4 bg-accent-50">
+    <div className="lp-menu flex uppercase font-bold text-xs md:text-sm gap-4 md:justify-start justify-center pt-4">
       {menu}
     </div>
   );


### PR DESCRIPTION
Fix unnecessary background for menu bar that interferes with Wavique theme.

The bug:

<img width="577" alt="Screenshot 2024-03-20 at 20 42 40" src="https://github.com/letterpad/letterpad/assets/294474/c7c4edbe-c9f6-4ffe-a6f4-b933411ca458">
