### PR TITLE
chore: hide client .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ bun run seed
 bun run start
 ```
 
+> **❗ Note**: Copy `apps/client/.env.sample` to `apps/client/.env`. Your blog will not work without setting the CLIENT_ID in `apps/client/.env`.  You can find the CLIENT_ID by logging into your admin dashboard and navigating to Settings > Keys.
+
 ### Using Docker
 
 If you prefer using Docker for deployment, you can run Letterpad with the following command:

--- a/apps/client/.env
+++ b/apps/client/.env
@@ -1,2 +1,0 @@
-CLIENT_ID=4aa02769-6fe4-419e-b1ba-be17ef8f58be
-API_URL=http://localhost:3000/api/graphql

--- a/apps/client/.env.sample
+++ b/apps/client/.env.sample
@@ -1,0 +1,2 @@
+CLIENT_ID=[GET THIS KEY FROM SETTINGS=>KEYS]
+API_URL=http://localhost:3000/api/graphql

--- a/apps/client/.gitignore
+++ b/apps/client/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 .env.production.local
 
 lib/graphql.ts
+.env


### PR DESCRIPTION
Removing the `.env` file from `client`. Users will have to copy over `.env.sample` to `.env` and then set the key.