### PR TITLE
fix: git ignore for local dev uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ data
 apps/docs/**
 
 .vscode
+
+apps/admin/public/uploads/*
+!apps/admin/public/uploads/logo.png


### PR DESCRIPTION
ignore all files except the logo in uploads. This allows us to correctly ignore the uploaded files from git untracked files during local development.