### PR TITLE
fix: post merge action

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-bun
+bun install


### PR DESCRIPTION
Post merge action includes calling "bun" but I guess it is meant to be `bun install` instead. 

The effect this fixes is showing bun help info upon `git pull` and install the new packages on bun install. For example, 

<img width="586" alt="Screenshot 2024-03-22 at 18 06 18" src="https://github.com/letterpad/letterpad/assets/294474/bf34ecbc-920b-4254-af5a-ca92964510f1">
