### PR TITLE
chore: chore: refactor post settings drawer and preview components

### DIFF
--- a/apps/admin/src/app/post/[postId]/_feature/components/post-settings/drawer.tsx
+++ b/apps/admin/src/app/post/[postId]/_feature/components/post-settings/drawer.tsx
@@ -40,13 +40,20 @@ export const PostSettingsModal = ({ visible, onClose, className }: IProps) => {
     <>
       <Drawer
         show={visible}
-        title={"Settings - " + post.title}
+        title={""}
         onClose={onClose}
         dir="top"
         className={classNames("w-screen z-20 bg-white h-screen", className)}
       >
         <div className="whitespace-normal lg:w-2/3 m-auto">
-          <div className="flex flex-col-reverse md:flex-row gap-10">
+          <div className="text-lg font-paragraph font-thin">
+            Settings for{" "}
+            <span className="font-bold dark:text-white text-black">
+              {post.title}
+            </span>
+          </div>
+          <hr className="my-4 border-t dark:border-slate-800 border-slate-200" />
+          <div className="pt-8 flex flex-col-reverse md:flex-row gap-10">
             <div className="flex-1 space-y-10">
               <Excerpt />
               {isPost && <PrimaryTag />}

--- a/apps/admin/src/app/post/[postId]/_feature/components/post-settings/preview.tsx
+++ b/apps/admin/src/app/post/[postId]/_feature/components/post-settings/preview.tsx
@@ -19,7 +19,7 @@ export const Preview: FC<Props> = ({ url, siteTitle }) => {
           "This is how various search engines and social posting will look like."
         }
       />
-      <div className="p-1 max-w-3xl mx-auto mt-8 bg-white dark:bg-neutral-800 shadow-md rounded-md flex flex-row gap-2">
+      <div className="p-4 max-w-3xl mx-auto mt-8 bg-white dark:bg-slate-800 shadow-md rounded-md flex flex-row gap-2">
         {watch("cover_image.src") && (
           <img
             src={watch("cover_image.src")}
@@ -36,7 +36,7 @@ export const Preview: FC<Props> = ({ url, siteTitle }) => {
               </div>
             </div>
           </div>
-          <h2 className="text-sm font-semibold text-blue-700 mt-2 leading-5">
+          <h2 className="text-sm font-semibold text-blue-500 mt-2 leading-5">
             <span className="hover:underline">
               {ellipsis(watch("title"), 57)}
             </span>

--- a/apps/admin/src/app/post/[postId]/_feature/components/subtitle.tsx
+++ b/apps/admin/src/app/post/[postId]/_feature/components/subtitle.tsx
@@ -1,7 +1,8 @@
 import { Editor } from "@tinymce/tinymce-react";
 import { PostWithAuthorAndTagsFragment } from "letterpad-graphql";
-import { memo } from "react";
+import { memo, useRef } from "react";
 import { Controller, useFormContext } from "react-hook-form";
+import { Editor as TinyMCEEditor } from "tinymce";
 import "./tinymce/core";
 
 import { subTitleEditorConfig, subTitleId } from "./tinymce/config";
@@ -9,23 +10,30 @@ import { subTitleEditorConfig, subTitleId } from "./tinymce/config";
 interface Props {}
 
 export const SubTitle: React.FC<Props> = memo(() => {
+  const editorRef = useRef<TinyMCEEditor | null>(null);
   const { control, watch } = useFormContext<PostWithAuthorAndTagsFragment>();
+  const sub_title = watch("sub_title");
   return (
     <Controller
       name="sub_title"
       control={control}
-      render={({ field: { onChange, value, onBlur } }) => {
+      render={({ field: { onChange, onBlur } }) => {
         return (
           <Editor
+            onInit={(_, editor) =>
+              (editorRef.current = editor as unknown as TinyMCEEditor)
+            }
             id={subTitleId}
-            value={value}
-            onEditorChange={(_, editor) => {
+            initialValue={sub_title}
+            onBlur={() => {
               if (watch("id")) {
-                const sub_title = editor.getContent({ format: "text" });
-                onChange(sub_title.trim());
+                const newtitle = editorRef.current?.getContent({
+                  format: "text",
+                });
+                if (sub_title !== newtitle) onChange(newtitle ?? "");
               }
+              onBlur();
             }}
-            onBlur={onBlur}
             init={subTitleEditorConfig}
           />
         );

--- a/apps/admin/src/app/post/[postId]/_feature/components/title.tsx
+++ b/apps/admin/src/app/post/[postId]/_feature/components/title.tsx
@@ -1,7 +1,8 @@
 import { Editor } from "@tinymce/tinymce-react";
 import { PostWithAuthorAndTagsFragment } from "letterpad-graphql";
-import { memo } from "react";
+import { memo, useRef } from "react";
 import { Controller, useFormContext } from "react-hook-form";
+import { Editor as TinyMCEEditor } from "tinymce";
 import "./tinymce/core";
 
 import { titleEditorConfig, titleId } from "./tinymce/config";
@@ -9,6 +10,7 @@ import { titleEditorConfig, titleId } from "./tinymce/config";
 interface Props {}
 
 export const Title: React.FC<Props> = memo(({}) => {
+  const editorRef = useRef<TinyMCEEditor | null>(null);
   const { control, watch } = useFormContext<PostWithAuthorAndTagsFragment>();
   const title = watch("title");
 
@@ -20,17 +22,20 @@ export const Title: React.FC<Props> = memo(({}) => {
       render={({ field: { onChange, onBlur } }) => {
         return (
           <Editor
+            onInit={(_, editor) =>
+              (editorRef.current = editor as unknown as TinyMCEEditor)
+            }
             id={titleId}
-            value={title}
-            onEditorChange={(_, editor) => {
+            initialValue={title}
+            onBlur={() => {
               if (watch("id")) {
-                const newtitle = editor?.getContent({
+                const newtitle = editorRef.current?.getContent({
                   format: "text",
                 });
                 if (title !== newtitle) onChange(newtitle ?? "");
               }
+              onBlur();
             }}
-            onBlur={onBlur}
             init={titleEditorConfig}
           />
         );

--- a/apps/admin/src/app/posts/_feature/header/index.tsx
+++ b/apps/admin/src/app/posts/_feature/header/index.tsx
@@ -44,7 +44,7 @@ const Actions = ({ changeStatus, id, status, onSettingsClick }) => {
           e.stopPropagation();
           onSettingsClick(id);
         }}
-        className="text-blue-600"
+        className="dark:text-white/80 text-black/60"
         data-tippy-content="Post Settings"
       >
         <BiCog size={20} />
@@ -54,7 +54,7 @@ const Actions = ({ changeStatus, id, status, onSettingsClick }) => {
           e.stopPropagation();
           changeStatus(id, PostStatusOptions.Trashed);
         }}
-        className="dark:text-red-800 text-red-500"
+        className="dark:text-red-500 text-red-500"
         data-tippy-content="Move to Trash"
       >
         <BiTrash size={20} />

--- a/packages/ui/src/components/drawer/drawer.tsx
+++ b/packages/ui/src/components/drawer/drawer.tsx
@@ -1,6 +1,6 @@
 import { animated, useSpring } from "@react-spring/web";
 import classNames from "classnames";
-import { FC, useEffect } from "react";
+import  { FC, ReactNode,useEffect } from "react";
 import { IoCloseOutline } from "react-icons/io5";
 
 import { useEscapeKey } from "./useEscapeKey";
@@ -9,9 +9,9 @@ import { disableScroll } from "../../utils";
 interface Props {
   show: boolean;
   onClose: () => void;
-  title: string;
-  children: React.ReactNode;
-  footer?: React.ReactNode;
+  title: string | ReactNode
+  children: ReactNode;
+  footer?: ReactNode;
   dir?: "right" | "left" | "top" | "bottom";
   className?: string;
   scale?: boolean;


### PR DESCRIPTION
Added cosmetic changes 💅 

- Changed icon colors in `/posts` page
- Title and Excerpt are not controlled inputs. Making it uncontrolled allows us to not save while typing.
- Settings modal window for posts has a decent looking title UI.