### PR TITLE
Add '90s sunset' theme

### DIFF
--- a/apps/client/themes/90s-sunset/home_posts.tsx
+++ b/apps/client/themes/90s-sunset/home_posts.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react';
+import { HomePostsProps } from 'types/pageTypes';
+import { Image } from 'ui/dist/isomorphic.mjs';
+
+import Link from '@/components/Link';
+
+export const HomePosts: FC<HomePostsProps> = ({ posts }) => {
+  return (
+    <div className="bg-gradient-to-r from-yellow-400 via-red-500 to-pink-500">
+      <div className="container mx-auto px-4 py-8">
+        <h2 className="text-4xl font-bold text-white">90s Sunset Posts</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-8">
+          {posts.rows.map((post) => (
+            <div key={post.id} className="rounded overflow-hidden shadow-lg bg-white">
+              <Link href={`/post/${post.slug}`}>
+                <Image src={post.cover_image.src} alt={post.title} className="w-full" />
+                <div className="px-6 py-4">
+                  <div className="font-bold text-xl mb-2">{post.title}</div>
+                  <p className="text-gray-700 text-base">
+                    {post.excerpt}
+                  </p>
+                </div>
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/client/themes/90s-sunset/index.tsx
+++ b/apps/client/themes/90s-sunset/index.tsx
@@ -1,0 +1,6 @@
+// Export HomePosts component dynamically for the "90s sunset" theme
+import dynamic from 'next/dynamic';
+
+export const HomePosts = dynamic(() =>
+  import('./home_posts').then((mod) => mod.HomePosts)
+);

--- a/apps/client/themes/getTheme.ts
+++ b/apps/client/themes/getTheme.ts
@@ -7,6 +7,7 @@ import * as GridDefaultTheme from './grid';
 import * as List from './list';
 import * as Wavique from './wavique';
 import * as Zenith from './zenith';
+import * as Sunset from './90s-sunset'; // Added 90s sunset theme import
 
 export interface Theme {
   HomePosts: ComponentType<HomePostsProps>;
@@ -32,6 +33,9 @@ export const getTheme: (theme?: string | null) => Theme = (theme) => {
       break;
     case 'zenith':
       selectedTheme = Zenith;
+      break;
+    case '90s-sunset': // Added case for 90s sunset theme
+      selectedTheme = Sunset;
       break;
     default:
       selectedTheme = GridDefaultTheme;


### PR DESCRIPTION
This pull request introduces a new theme called "90s sunset" to the Letterpad repository, enhancing the theme selection with vibrant sunset colors.

- **Theme Selection Logic Update**: Adds the "90s sunset" theme to the theme selection logic in `getTheme.ts`, allowing it to be chosen as a theme option.
- **New Theme Directory and Components**: Creates a new directory `apps/client/themes/90s-sunset` with an `index.tsx` file to dynamically export the `HomePosts` component, and a `home_posts.tsx` file implementing the `HomePosts` component. This component utilizes Tailwind CSS sunset colors for styling, aligning with the theme's aesthetic.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/letterpad/letterpad?shareId=0e26399a-d8f5-4e92-9de4-dce6d1842179).